### PR TITLE
add path to find binary as configuration option

### DIFF
--- a/config.sample.sh
+++ b/config.sample.sh
@@ -65,6 +65,12 @@ RECEIVE_PIPE="ssh ${REMOTE_SERVER} zfs receive -vFd"
 ## path to zfs binary
 ZFS=/sbin/zfs
 
+## path to GNU find binary
+##
+## solaris `find` does not support the -maxdepth option, which is required
+## on solaris 11, GNU find is typically located at /usr/bin/gfind
+FIND=/usr/bin/find
+
 ## get the current date info
 DOW=$(date "+%a")
 MOY=$(date "+%m")

--- a/zfs-replicate.sh
+++ b/zfs-replicate.sh
@@ -14,7 +14,7 @@ check_old_log() {
         ## initialize index
         local index=0
         ## find existing logs
-        for log in $(find ${LOGBASE} -maxdepth 1 -type f -name autorep-\*); do
+        for log in $(${FIND} ${LOGBASE} -maxdepth 1 -type f -name autorep-\*); do
                 ## get file change time via stat (platform specific)
                 case "$(uname -s)" in
                     Linux|SunOS)


### PR DESCRIPTION
When the script is run on Solaris, it fails because the Solaris version of `find` doesn't support the -maxdepth option.

The GNU `find` is installed by default and called `gfind`, so I added a variable to the configuration file and use that variable instead of `find` in the script. Since the other defaults assume you're running Linux, I used `/usr/bin/find` as the default path.

Another option would be to do some platform detection and pick the right find automatically, but I thought this would be more straightforward.
