### PR TITLE
Adds Set Name to allow tracking of multiple backup sets

### DIFF
--- a/config.sample.sh
+++ b/config.sample.sh
@@ -3,6 +3,9 @@
 ## file revision $Id$
 ##
 
+## OPTIONAL: Add a Set Name to keep multiple backup sets seperate.
+# SETNAME="name-of-set"
+
 ## datasets to replicate - use zfs paths not mount points...
 ## format is local_pool/local_fs:remote_pool or
 ## local_pool/local_fs:remote_pool/remote_fs the local name
@@ -82,7 +85,11 @@ CYR=$(date "+%Y")
 ## ie: pool0/someplace@autorep-${NAMETAG}
 NAMETAG="${MOY}${DOM}${CYR}_${NOW}"
 
+## check if a set name is specified
+## This code shouldn't be in config.
+if [ -z ${SETNAME+x} ]; then SETSEP=""; else SETSEP="-"; fi
+
 ## the log file...you need to prepend with
 ## autorep- in order for log cleanup to work
 ## using the default below is strongly suggested
-LOGFILE="${LOGBASE}/autorep-${NAMETAG}.log"
+LOGFILE="${LOGBASE}/autorep-${SETNAME}${SETSEP}${NAMETAG}.log"

--- a/zfs-replicate.sh
+++ b/zfs-replicate.sh
@@ -14,7 +14,7 @@ check_old_log() {
         ## initialize index
         local index=0
         ## find existing logs
-        for log in $(${FIND} ${LOGBASE} -maxdepth 1 -type f -name autorep-\*); do
+        for log in $(${FIND} ${LOGBASE} -maxdepth 1 -type f -name autorep-${SETNAME}${SETSEP}\*); do
                 ## get file change time via stat (platform specific)
                 case "$(uname -s)" in
                     Linux|SunOS)
@@ -135,7 +135,7 @@ do_snap() {
         ## make sure we aren't ever creating simultaneous snapshots
         check_lock "${LOGBASE}/.snapshot.lock"
         ## set our snap name
-        local sname="autorep-${NAMETAG}"
+        local sname="autorep-${SETNAME}${SETSEP}${NAMETAG}"
         ## generate snapshot list and cleanup old snapshots
         for foo in $REPLICATE_SETS; do
                 ## split dataset into local and remote parts and trim trailing slashes
@@ -156,10 +156,10 @@ do_snap() {
                 ## they were made by this script
                 if [ $RECURSE_CHILDREN -ne 1 ]; then
                     local temps=$($ZFS list -Hr -o name -s creation -t snapshot -d 1 ${local_set}|\
-                        grep "${local_set}\@autorep-")
+                        grep "${local_set}\@autorep-${SETNAME}${SETSEP}")
                 else
                     local temps=$($ZFS list -Hr -o name -s creation -t snapshot ${local_set}|\
-                        grep "${local_set}\@autorep-")
+                        grep "${local_set}\@autorep-${SETNAME}${SETSEP}")
                 fi
                 ## just a counter var
                 local index=0


### PR DESCRIPTION
Separates the relationships between separate backup sets, so that you can maintain snapshots between different sets for an alternating backup schedule.
