### PR TITLE
improve logging and add tests

### DIFF
--- a/test/find.sh
+++ b/test/find.sh
@@ -7,8 +7,11 @@ set -eu
 (set -o pipefail 2> /dev/null) && set -o pipefail
 
 _fakeFIND() {
-  printf "find %s\n" "$*"
+  path="$1"
+  printf "%s/autorep-test1.log\n" "$path"
+  printf "%s/autorep-test2.log\n" "$path"
+  printf "%s/autorep-test3.log\n" "$path"
   return 0
 }
 
-_fakeZFS "$@"
+_fakeFIND "$@"


### PR DESCRIPTION
Previous logging was always sent to stdout in functions, this prevented some functions like snapList from logging the commands sent as these functions printed return values used by other functions. To fix this, all user facing logging has been switched to stderr which is not picked up by calling functions. This commit also adds tests for the --status/-s and --help/-h options which includes testing of the sortLogs function.